### PR TITLE
[MAR-3084] Prep this repo for a new shared package workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@4.6.0
+
+references:
+  container_config_node: &container_config_node
+    working_directory: ~/project/build
+    docker:
+      - image: cimg/node:<< parameters.node-version >>
+    parameters:
+      node-version:
+        default: "24.15"
+        type: string
+
+  workspace_root: &workspace_root ~/project
+
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: *workspace_root
+
+jobs:
+  install:
+    <<: *container_config_node
+    steps:
+      - checkout
+      - node/install-npm:
+          version: "11.7.0"
+      - run:
+          name: Install project dependencies
+          command: npm ci
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - build
+
+  test:
+    <<: *container_config_node
+    steps:
+      - *attach_workspace
+      - run:
+          name: Run repo tests
+          command: npm test
+
+workflows:
+  test:
+    jobs:
+      - install:
+          name: install-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: ["26.2", "24.15", "22.22"]
+      - test:
+          name: test-v<< matrix.node-version >>
+          requires:
+            - install-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: ["26.2", "24.15", "22.22"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,16 @@ jobs:
           name: Run repo tests
           command: npm test
 
+  lint:
+    <<: *container_config_node
+    steps:
+      - *attach_workspace
+      - run:
+          name: Run repo linting
+          command: npm run lint
+
 workflows:
-  test:
+  test-and-lint:
     jobs:
       - install:
           name: install-v<< matrix.node-version >>
@@ -57,3 +65,7 @@ workflows:
           matrix:
             parameters:
               node-version: ["26.2", "24.15", "22.22"]
+      - lint:
+          name: lint-v24.15
+          requires:
+            - install-v24.15

--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # Martech tooling
 
-This repo contains different shareable tooling and other pieces of common code or similar for Martech engineers.
-Currently, there is a team-wide `eslint-config` available on the `eslint-config-martech` branch. The `main` branch is an orphaned branch, so contains different content from our `eslint`-related branch.
+This repo contains shareable tooling and common packages for Martech engineers.
 
-The main branch also contains useful scripts.
+## Workspace layout
 
-## Contents
+This repo uses npm workspaces for packages in `packages/*`.
 
-- [Contents](#contents)
-- [Branches](#branches)
-- [Contact](#contact)
+Current workspace packages:
 
+- `packages/workspace-smoke-test`
 
-## Branches
+The `scripts/` directory remains standalone and is not part of the workspace graph.
 
-The idea is that we can create orphan branches for use as `npm` packages, so we consolidate and can easily share common tooling for our different repos and projects.
+## Install
 
-Currently, we only have one other branch of interest:
-- `eslint-config-martech`
+Install dependencies from the repo root:
+
+```bash
+npm install
+```
+
+## Commands
+
+Run workspace tests from the repo root:
+
+```bash
+npm test
+```
+
+Target the smoke-test package directly:
+
+```bash
+npm run test -w packages/workspace-smoke-test
+```
 
 ## Contact
 
-If you have any questions, or need any help, either [raise an issue](https://github.com/Financial_times/ip-martech-tooling/issues), speak to [us on Slack](https://financialtimes.slack.com/archives/C017GUUCB3P), or via [email](mailto:ip.martech@ft.com).
+If you have any questions, or need any help, either [raise an issue](https://github.com/Financial-Times/ip-martech-tooling/issues), speak to [us on Slack](https://financialtimes.slack.com/archives/C017GUUCB3P), or via [email](mailto:ip.martech@ft.com).

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ npm install
 
 ## Commands
 
-Run workspace tests from the repo root:
+Run repo checks from the repo root:
 
 ```bash
+npm run lint
 npm test
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+	"extends": ["./node_modules/@dotcom-reliability-kit/biome-config/config.json"],
+	"formatter": {
+		"indentStyle": "tab",
+		"indentWidth": 4,
+		"lineWidth": 100
+	},
+	"linter": {
+		"rules": {
+			"suspicious": {
+				"noExplicitAny": "off"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single",
+			"jsxQuoteStyle": "double",
+			"trailingCommas": "none"
+		}
+	},
+	"json": {
+		"formatter": {
+			"enabled": false
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,220 @@
       "workspaces": [
         "packages/*"
       ],
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
+        "@dotcom-reliability-kit/biome-config": "^1.0.0",
+        "typescript": "^5.8.3"
+      },
       "engines": {
         "node": "^22.12 || ^24 || ^26"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.16",
+        "@biomejs/cli-darwin-x64": "2.4.16",
+        "@biomejs/cli-linux-arm64": "2.4.16",
+        "@biomejs/cli-linux-arm64-musl": "2.4.16",
+        "@biomejs/cli-linux-x64": "2.4.16",
+        "@biomejs/cli-linux-x64-musl": "2.4.16",
+        "@biomejs/cli-win32-arm64": "2.4.16",
+        "@biomejs/cli-win32-x64": "2.4.16"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/biome-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/biome-config/-/biome-config-1.0.0.tgz",
+      "integrity": "sha512-iIqCTHve9qSw+qBrwTUiSlZIbck3m59waOArFepeA+mJFHCwjU/0eGTDcWmyaGuknEmwnB6cnQqPfxrQ763+Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.12 || ^24"
+      },
+      "peerDependencies": {
+        "@biomejs/biome": ">=2.3.11"
       }
     },
     "node_modules/@financial-times/workspace-smoke-test": {
       "resolved": "packages/workspace-smoke-test",
       "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "packages/workspace-smoke-test": {
       "name": "@financial-times/workspace-smoke-test",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "ip-martech-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ip-martech-tooling",
+      "version": "0.0.0",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "engines": {
+        "node": "^22.12 || ^24 || ^26"
+      }
+    },
+    "node_modules/@financial-times/workspace-smoke-test": {
+      "resolved": "packages/workspace-smoke-test",
+      "link": true
+    },
+    "packages/workspace-smoke-test": {
+      "name": "@financial-times/workspace-smoke-test",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ip-martech-tooling",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "description": "Shareable tooling and common packages for Martech engineers.",
   "repository": {
@@ -14,7 +15,13 @@
     "packages/*"
   ],
   "scripts": {
+    "lint": "biome check",
     "test": "npm run test --workspaces --if-present"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
+    "@dotcom-reliability-kit/biome-config": "^1.0.0",
+    "typescript": "^5.8.3"
   },
   "engines": {
     "node": "^22.12 || ^24 || ^26"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ip-martech-tooling",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shareable tooling and common packages for Martech engineers.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/ip-martech-tooling.git"
+  },
+  "homepage": "https://github.com/Financial-Times/ip-martech-tooling",
+  "bugs": "https://github.com/Financial-Times/ip-martech-tooling/issues",
+  "license": "MIT",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "test": "npm run test --workspaces --if-present"
+  },
+  "engines": {
+    "node": "^22.12 || ^24 || ^26"
+  }
+}

--- a/packages/workspace-smoke-test/index.js
+++ b/packages/workspace-smoke-test/index.js
@@ -1,0 +1,3 @@
+export function workspaceSmokeTest() {
+	return 'workspace-smoke-test';
+}

--- a/packages/workspace-smoke-test/package.json
+++ b/packages/workspace-smoke-test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@financial-times/workspace-smoke-test",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/packages/workspace-smoke-test/test/index.spec.js
+++ b/packages/workspace-smoke-test/test/index.spec.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { workspaceSmokeTest } from '../index.js';
+
+test('workspace smoke test package is wired into the repo', () => {
+	assert.strictEqual(workspaceSmokeTest(), 'workspace-smoke-test');
+});

--- a/scripts/create-consent-csv.js
+++ b/scripts/create-consent-csv.js
@@ -17,35 +17,38 @@ If you want to create files each with 10,000 records:
 node ./create-consent-csv.js 10000
 */
 
-const fs = require("fs");
+const fs = require('node:fs');
 const { v4: uuid } = require('uuid');
 const now = new Date();
 
-const createCsv = (numberOfRows) => {
-  console.log("Starting process...");
-  const consentFields =
-    `marketing-email,accept,${now / 1000},unlimited`;
-
-  console.log(`Creating email data. ${numberOfRows} records...`);
-
-  const csvEmailData = Array.from(Array(numberOfRows)).map((row) => {
-    return [(`${now.getDate()}-${now.getMonth()+1}-${uuid()}-test@test.com`)];
-  });
-
-  console.log("Writing to file...");
-  const fileEmail = fs.createWriteStream("email.csv");
-  const fileConsent = fs.createWriteStream("consent.csv");
-
-  fileEmail.write("email" + "\n");
-  fileConsent.write("email,category,action,timestamp,valid_until" + "\n");
-  csvEmailData.forEach(function (v) {
-    fileEmail.write(v.join(",") + "\n");
-    fileConsent.write(v.join(",") + ',' + consentFields + "\n");
-  });
-  fileEmail.end();
-  fileConsent.end();
-  console.log("Completed!!");
+const log = (message) => {
+	process.stdout.write(`${message}\n`);
 };
-console.log(process.argv[2]);
-const count = process.argv[2] ? process.argv[2] : 10;
+
+const createCsv = (numberOfRows) => {
+	log('Starting process...');
+	const consentFields = `marketing-email,accept,${now / 1000},unlimited`;
+
+	log(`Creating email data. ${numberOfRows} records...`);
+
+	const csvEmailData = Array.from({ length: numberOfRows }).map(() => {
+		return [`${now.getDate()}-${now.getMonth() + 1}-${uuid()}-test@test.com`];
+	});
+
+	log('Writing to file...');
+	const fileEmail = fs.createWriteStream('email.csv');
+	const fileConsent = fs.createWriteStream('consent.csv');
+
+	fileEmail.write('email\n');
+	fileConsent.write('email,category,action,timestamp,valid_until\n');
+	csvEmailData.forEach((entry) => {
+		fileEmail.write(`${entry.join(',')}\n`);
+		fileConsent.write(`${entry.join(',')},${consentFields}\n`);
+	});
+	fileEmail.end();
+	fileConsent.end();
+	log('Completed!!');
+};
+
+const count = process.argv[2] ?? 10;
 createCsv(+count);


### PR DESCRIPTION
> [!NOTE]  
> All thoughts and ideas are very welcome for this PR!
>
> Please do get involved and ask any questions if you have any, or suggest alternatives if you think we should share code via some other means. Or not share code at all! Let’s chat about it.

TL;DR: This PR sets up `ip-martech-tooling` as a standardised home for shared Martech packages, using a workspace/CI/tooling shape aligned with `@dotcom-reliability-kit`.

## What is this my dude

This PR does two main things:

1. sets up the repo as an [npm workspace](https://docs.npmjs.com/cli/v11/using-npm/workspaces) with a minimal smoke-test package and root-based CI
2. adds lint tooling at the root and a CI lint job to go with it

The intent is to establish a clean, repeatable workflow for sharing code across current and upcoming Martech systems, before adding our first real package (which will be fetch-with-retries).

A further PR will introduce a publication workflow to share packages internally via Cloudsmith. I’ve already tested it out and it works real nice. The existing mechanism for sharing eslint configs remains untouched for now, but we can look at that later.

## Why this is happening

We currently own [52(!) repos](https://github.com/orgs/Financial-Times/repositories?q=props.teamCode%3Aip-martech+archived%3Afalse) in our team, and there are some common patterns across multiple Martech systems. Admittedly, in theory many of these repos will be decommissioned in the coming months, but it seems likely that the same patterns will keep occurring for any replacement systems we build. If we want to reduce the maintenance burden for our future selves, we should establish a good setup for shared tooling while we have some time.

This PR attempts to creates that baseline. It deliberately follows the same broad setup as the [@dotcom-reliability-kit](https://github.com/Financial-Times/dotcom-reliability-kit) where it makes sense:
- [npm workspaces](https://docs.npmjs.com/cli/v11/using-npm/workspaces) at the repo root
- shared dev tooling at the root
- root CI that runs package checks
- same [Biome](https://biomejs.dev/) setup as theirs (removing the need for eslint, while also introducing [prettier](https://prettier.io/)-like formatting)

These changes give us a more standardised internal package workflow now, and keeps open the possibility that anything useful we build here could be handed over or aligned with wider, cross-department package conventions later.

## What changed

### Workspace/bootstrap
- added a private root `package.json` and `package-lock.json`
- manages packages via `packages/*`, where shared tooling will live
- keeps the existing `scripts/` outside the workspace graph, assuming this folder is just for handy scripts we use every so often, and don’t need sharing across repos
- adds a tiny smoke-test package to prove the workspace and CI wiring works end-to-end

### Tooling/standards
- added root Biome config and a root `lint` task
- added a lint job in CircleCI
- cleaned up the existing script in `/scripts` based on the Biome setup

## Why the smoke-test package exists

The smoke-test package is here temporarily, until I open a PR to introduce this repo’s first shared package using the new setup: `fetch-with-retries`. That’s provided we’re all happy with this new setup!

In the meantime, the job of this smoke-test package is to prove that:
- the repo can host a package cleanly
- root install/test flows work
- CI is exercising a real workspace package

That keeps the repo plumbing changes honest instead of leaving us with infrastructure that is only theoretically usable.

## What this enables next

With this in place, we can add real shared packages in a much cleaner way:
- package code lives under `packages/`
- tests run consistently from the repo root and in CI
- linting is enforced once at the repo level
- future packages can follow the same shape without inventing their own tooling
- no more switching between branches for different packages

That’s it for now!

## A jovial visual representation of changes made

<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbno3cnJwemdqc2NlMnNvNWRiNTRsbmRxM2oxZXZmdnN1M3pxaDhoYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Nda9GjMZ6BQpa/giphy.gif" width="450" alt="">